### PR TITLE
Fix to `Solver.read` to allow single precision files to be loaded when using default double precision

### DIFF
--- a/bt_ocean/grid.py
+++ b/bt_ocean/grid.py
@@ -30,11 +30,9 @@ class Grid:
     N_y : Integral
         Number of :math:`y`-dimension divisions.
     idtype : type
-        Integer scalar data type. Defaults to `jax.numpy.int64` if 64-bit is
-        enabled, and `jax.numpy.int32` otherwise.
+        Integer scalar data type. Defaults to :func:`.default_idtype()`.
     fdtype : type
-        Floating point scalar data type. Defaults to `jax.numpy.float64` if
-        64-bit is enabled, and `jax.numpy.float32` otherwise.
+        Floating point scalar data type. Defaults to :func:`.default_fdtype()`.
     """
 
     def __init__(self, L_x, L_y, N_x, N_y, *, idtype=None, fdtype=None):

--- a/bt_ocean/model.py
+++ b/bt_ocean/model.py
@@ -349,7 +349,6 @@ class Solver(ABC):
             - `'r'` : Linear drag coefficient, :math:`r`.
             - `dt` : Time step size.
 
-    
     idtype : type
         Integer scalar data type. Defaults to :func:`.default_idtype()`.
     fdtype : type

--- a/bt_ocean/precision.py
+++ b/bt_ocean/precision.py
@@ -9,11 +9,30 @@ import keras
 
 __all__ = \
     [
+        "x64_disabled",
         "x64_enabled",
 
         "default_idtype",
         "default_fdtype"
     ]
+
+
+@contextmanager
+def x64_disabled():
+    """Context manager for temporarily disabling the `'jax_enable_x64'` JAX
+    configuration option, and for temporarily setting the Keras default float
+    type to single precision.
+    """
+
+    x64_enabled = jax.config.x64_enabled
+    jax.config.update("jax_enable_x64", False)
+    floatx = keras.backend.floatx()
+    keras.backend.set_floatx("float32")
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", x64_enabled)
+        keras.backend.set_floatx(floatx)
 
 
 @contextmanager

--- a/bt_ocean/precision.py
+++ b/bt_ocean/precision.py
@@ -25,10 +25,10 @@ def x64_disabled():
     """
 
     x64_enabled = jax.config.x64_enabled
-    jax.config.update("jax_enable_x64", False)
     floatx = keras.backend.floatx()
-    keras.backend.set_floatx("float32")
     try:
+        jax.config.update("jax_enable_x64", False)
+        keras.backend.set_floatx("float32")
         yield
     finally:
         jax.config.update("jax_enable_x64", x64_enabled)
@@ -43,10 +43,10 @@ def x64_enabled():
     """
 
     x64_enabled = jax.config.x64_enabled
-    jax.config.update("jax_enable_x64", True)
     floatx = keras.backend.floatx()
-    keras.backend.set_floatx("float64")
     try:
+        jax.config.update("jax_enable_x64", True)
+        keras.backend.set_floatx("float64")
         yield
     finally:
         jax.config.update("jax_enable_x64", x64_enabled)


### PR DESCRIPTION
Closes #21