### PR TITLE
Basic 1D finite difference code generator

### DIFF
--- a/bt_ocean/finite_difference.py
+++ b/bt_ocean/finite_difference.py
@@ -8,7 +8,7 @@ Finite difference coefficients are found as in equation (1.19) in
 """
 
 from functools import lru_cache, partial
-from numbers import Complex, Rational, Real
+from numbers import Rational, Real
 
 import jax
 import jax.numpy as jnp
@@ -65,8 +65,6 @@ def _difference_coefficients(beta, order):
     def is_real(v):
         if isinstance(v, Real):
             return True
-        elif isinstance(v, Complex):
-            return False
         elif isinstance(v, sp.core.expr.Expr):
             return v.is_real
         else:

--- a/bt_ocean/finite_difference.py
+++ b/bt_ocean/finite_difference.py
@@ -1,0 +1,145 @@
+"""Finite difference utilities.
+"""
+
+from functools import partial
+from numbers import Real
+
+import jax
+import jax.numpy as jnp
+import sympy as sp
+
+__all__ = \
+    [
+        "diff"
+    ]
+
+
+def difference_coefficients(beta, order):
+    """Compute 1D finite difference coefficients of maximal order of accuracy.
+
+    Parameters
+    ----------
+
+    beta : Sequence[Real, ...]
+        Grid location displacements.
+    order : Integral
+        Derivative order.
+
+    Returns
+    -------
+
+    Sequence[:class:`sympy.Rational`, ...]
+        Finite difference coefficients.
+    """
+
+    beta = tuple(map(sp.Rational, beta))
+    if not all(isinstance(beta_i, Real) for beta_i in beta):
+        raise ValueError("Invalid type")
+    N = len(beta)
+    if order >= N:
+        raise ValueError("Invalid order")
+
+    a = tuple(sp.Symbol("{a_" + f"{i}" + "}", real=True)
+              for i in range(N))
+    eqs = [sum((a[i] * sp.Rational(beta[i] ** j, sp.factorial(j))
+                for i in range(N)), start=sp.Integer(0))
+           for j in range(N)]
+    eqs[order] -= sp.Integer(1)
+
+    soln, = sp.linsolve(eqs, a)
+    return tuple(map(sp.Rational, soln))
+
+
+@partial(jax.jit, static_argnames={"order", "N", "axis", "i0", "i1", "boundary_expansion"})
+def diff(u, dx, order, N, *, axis=-1, i0=None, i1=None, boundary_expansion=None):
+    """Compute a centred finite difference approximation to a derivative for
+    data stored on a uniform grid. Transitions to one-sided differencing as the
+    end-points are approached. Selects an additional right-sided point if
+    `N` is even.
+
+    Parameters
+    ----------
+
+    u : :class:`jax.Array`
+        Field to difference.
+    dx : Real
+        Grid spacing.
+    order : Integral
+        Derivative order.
+    N : Integral
+        Number of grid points in the difference approximation.
+    axis : Integral
+        Axis.
+    i0 : Integral
+        Index lower limit. Values with index less than the index defined by
+        `i0` are set to zero.
+    i1 : Integral
+        Index upper limit. Values with index greater than or equal to the index
+        defined by `i1` are set to zero.
+    boundary_expansion : bool
+        Whether to use one additional grid point for one-sided differencing
+        near the boundary. Defaults to `True` if `order` is even and `False`
+        otherwise.
+
+    Returns
+    -------
+
+    :class:`jax.Array`
+        Finite difference approximation.
+    """
+
+    if axis < 0:
+        axis = len(u.shape) + axis
+    if axis < 0 or axis >= len(u.shape):
+        raise ValueError("Invalid axis")
+    if boundary_expansion is None:
+        boundary_expansion = (order % 2) == 0
+    if u.shape[axis] < N + int(bool(boundary_expansion)):
+        raise ValueError("Insufficient points")
+
+    i0_b, i1_b = i0, i1
+    del i0, i1
+    if i0_b is None:
+        i0_b = 0
+    elif i0_b < 0:
+        i0_b = u.shape[axis] + i0_b
+    if i1_b is None:
+        i1_b = u.shape[axis]
+    elif i1_b < 0:
+        i1_b = u.shape[axis] + i1_b
+
+    u = jnp.moveaxis(u, axis, -1)
+
+    v = jnp.zeros_like(u)
+    dtype = u.dtype.type
+    i0 = -(N // 2)
+    i1 = i0 + N
+    parity = (-1) ** order
+
+    for i in range(max(-i0, i1 - 1)):
+        beta = tuple(range(-i, -i + N + int(bool(boundary_expansion))))
+        alpha = tuple(map(dtype, difference_coefficients(beta, order)))
+        if i < -i0 and i >= i0_b:
+            # Left end points
+            assert len(alpha) == len(beta)
+            for alpha_j, beta_j in zip(alpha, beta):
+                v = v.at[..., i].add(alpha_j * u[..., i + beta_j])
+        if i < i1 - 1 and u.shape[-1] - 1 - i < i1_b:
+            # Right end points
+            assert len(alpha) == len(beta)
+            for alpha_j, beta_j in zip(alpha, beta):
+                v = v.at[..., u.shape[-1] - 1 - i].add(
+                    parity * alpha_j * u[..., u.shape[-1] - 1 - i - beta_j])
+
+    # Center
+    beta = tuple(range(i0, i1))
+    alpha = tuple(map(dtype, difference_coefficients(beta, order)))
+    i0_c = max(-i0, i0_b)
+    i1_c = min(u.shape[-1] - i1 + 1, i1_b)
+    assert len(alpha) == len(beta)
+    for alpha_i, beta_i in zip(alpha, beta):
+        v = v.at[..., i0_c:i1_c].add(
+            alpha_i * u[..., i0_c + beta_i:i1_c + beta_i])
+
+    v = jnp.moveaxis(v, -1, axis)
+    return v / (dx ** order)

--- a/bt_ocean/finite_difference.py
+++ b/bt_ocean/finite_difference.py
@@ -37,9 +37,9 @@ def difference_coefficients(beta, order):
         if isinstance(v, Rational):
             return sp.Rational(v)
         elif isinstance(v, sp.core.expr.Expr):
-            return sp.Expr(v)
-        else:
             return v
+        else:
+            return sp.Expr(v)
 
     return _difference_coefficients(tuple(map(displacement_cast, beta)), order)
 

--- a/bt_ocean/finite_difference.py
+++ b/bt_ocean/finite_difference.py
@@ -28,7 +28,7 @@ def difference_coefficients(beta, order):
     Returns
     -------
 
-    Sequence[:class:`sympy.Rational`, ...]
+    tuple[:class:`sympy.Rational`, ...]
         Finite difference coefficients.
     """
 
@@ -39,7 +39,7 @@ def difference_coefficients(beta, order):
     if order >= N:
         raise ValueError("Invalid order")
 
-    a = tuple(sp.Symbol("{a_" + f"{i}" + "}", real=True)
+    a = tuple(sp.Symbol("a_{" + f"{i}" + "}", real=True)
               for i in range(N))
     eqs = [sum((a[i] * sp.Rational(beta[i] ** j, sp.factorial(j))
                 for i in range(N)), start=sp.Integer(0))
@@ -109,7 +109,6 @@ def diff(u, dx, order, N, *, axis=-1, i0=None, i1=None, boundary_expansion=None)
         i1_b = u.shape[axis] + i1_b
 
     u = jnp.moveaxis(u, axis, -1)
-
     v = jnp.zeros_like(u)
     dtype = u.dtype.type
     i0 = -(N // 2)

--- a/bt_ocean/finite_difference.py
+++ b/bt_ocean/finite_difference.py
@@ -1,6 +1,6 @@
 """Finite difference utilities.
 
-Finite difference coefficients are found as in equation (1.19) of
+Finite difference coefficients are found as in equation (1.19) in
 
     - Randall J. LeVeque, 'Finite difference methods for ordinary and partial
       differential equations', Society for Industrial and Applied Mathematics,
@@ -26,7 +26,7 @@ __all__ = \
 def difference_coefficients(beta, order):
     """Compute 1D finite difference coefficients of maximal order of accuracy.
 
-     Finite difference coefficients are found as in equation (1.19) of
+     Finite difference coefficients are found as in equation (1.19) in
 
         - Randall J. LeVeque, 'Finite difference methods for ordinary and
           partial differential equations', Society for Industrial and Applied
@@ -77,6 +77,11 @@ def _difference_coefficients(beta, order):
         assumptions["real"] = True
     a = tuple(sp.Symbol("_bt_ocean__finite_difference_{" + f"{i}" + "}", **assumptions)
               for i in range(N))
+
+    # Equation (1.19) in
+    #     Randall J. LeVeque, 'Finite difference methods for ordinary and
+    #     partial differential equations', Society for Industrial and Applied
+    #     Mathematics, 2007
     eqs = [sum((a[i] * ((beta[i] ** j) / sp.factorial(j))
                 for i in range(N)), start=sp.Integer(0))
            for j in range(N)]

--- a/bt_ocean/finite_difference.py
+++ b/bt_ocean/finite_difference.py
@@ -1,4 +1,10 @@
 """Finite difference utilities.
+
+Finite difference coefficients are found as in equation (1.19) of
+
+    - Randall J. LeVeque, 'Finite difference methods for ordinary and partial
+      differential equations', Society for Industrial and Applied Mathematics,
+      2007
 """
 
 from functools import lru_cache, partial
@@ -19,6 +25,12 @@ __all__ = \
 
 def difference_coefficients(beta, order):
     """Compute 1D finite difference coefficients of maximal order of accuracy.
+
+     Finite difference coefficients are found as in equation (1.19) of
+
+        - Randall J. LeVeque, 'Finite difference methods for ordinary and
+          partial differential equations', Society for Industrial and Applied
+          Mathematics, 2007
 
     Parameters
     ----------

--- a/bt_ocean/grid.py
+++ b/bt_ocean/grid.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 from functools import cached_property, partial
 from numbers import Real
 
+from .finite_difference import diff
 from .precision import default_idtype, default_fdtype
 
 __all__ = \
@@ -226,12 +227,8 @@ class Grid:
             The derivative.
         """
 
-        D = jnp.zeros_like(u).at[1:-1, :].set(
-            (u[2:, :] - u[:-2, :]) / (2 * self.dx))
-        if boundary:
-            D = D.at[0, :].set((-1.5 * u[0, :] + 2 * u[1, :] - 0.5 * u[2, :]) / self.dx)
-            D = D.at[-1, :].set(-(-1.5 * u[-1, :] + 2 * u[-2, :] - 0.5 * u[-3, :]) / self.dx)
-        return D
+        return diff(u, dx=self.dx, order=1, N=3, axis=0,
+                    i0=None if boundary else 1, i1=None if boundary else -1)
 
     def D_y(self, u, boundary=True):
         """Compute a :math:`y`-direction first derivative.
@@ -251,12 +248,8 @@ class Grid:
             The derivative.
         """
 
-        D = jnp.zeros_like(u).at[:, 1:-1].set(
-            (u[:, 2:] - u[:, :-2]) / (2 * self.dy))
-        if boundary:
-            D = D.at[:, 0].set((-1.5 * u[:, 0] + 2 * u[:, 1] - 0.5 * u[:, 2]) / self.dy)
-            D = D.at[:, -1].set(-(-1.5 * u[:, -1] + 2 * u[:, -2] - 0.5 * u[:, -3]) / self.dy)
-        return D
+        return diff(u, dx=self.dy, order=1, N=3, axis=1,
+                    i0=None if boundary else 1, i1=None if boundary else -1)
 
     def D_xx(self, u, boundary=True):
         """Compute an :math:`x`-direction second derivative.
@@ -276,12 +269,8 @@ class Grid:
             The derivative.
         """
 
-        D = jnp.zeros_like(u).at[1:-1, :].set(
-            (u[2:, :] - 2 * u[1:-1, :] + u[:-2, :]) / (self.dx ** 2))
-        if boundary:
-            D = D.at[0, :].set((2 * u[0, :] - 5 * u[1, :] + 4 * u[2, :] - u[3, :]) / (self.dx ** 2))
-            D = D.at[-1, :].set((2 * u[-1, :] - 5 * u[-2, :] + 4 * u[-3, :] - u[-4, :]) / (self.dx ** 2))
-        return D
+        return diff(u, dx=self.dx, order=2, N=3, axis=0,
+                    i0=None if boundary else 1, i1=None if boundary else -1)
 
     def D_yy(self, u, boundary=True):
         """Compute a :math:`y`-direction second derivative.
@@ -301,12 +290,8 @@ class Grid:
             The derivative.
         """
 
-        D = jnp.zeros_like(u).at[:, 1:-1].set(
-            (u[:, 2:] - 2 * u[:, 1:-1] + u[:, :-2]) / (self.dy ** 2))
-        if boundary:
-            D = D.at[:, 0].set((2 * u[:, 0] - 5 * u[:, 1] + 4 * u[:, 2] - u[:, 3]) / (self.dy ** 2))
-            D = D.at[:, -1].set((2 * u[:, -1] - 5 * u[:, -2] + 4 * u[:, -3] - u[:, -4]) / (self.dy ** 2))
-        return D
+        return diff(u, dx=self.dy, order=2, N=3, axis=1,
+                    i0=None if boundary else 1, i1=None if boundary else -1)
 
     def integrate(self, u):
         """

--- a/bt_ocean/grid.py
+++ b/bt_ocean/grid.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 from functools import cached_property, partial
 from numbers import Real
 
-from .finite_difference import diff
+from .finite_difference import diff_bounded as diff
 from .precision import default_idtype, default_fdtype
 
 __all__ = \

--- a/bt_ocean/grid.py
+++ b/bt_ocean/grid.py
@@ -7,13 +7,16 @@ import jax.numpy as jnp
 from functools import cached_property, partial
 from numbers import Real
 
-from .finite_difference import diff_bounded as diff
+from .finite_difference import diff_bounded, order_reversed
 from .precision import default_idtype, default_fdtype
 
 __all__ = \
     [
         "Grid"
     ]
+
+
+diff = partial(diff_bounded, interior_order=order_reversed)
 
 
 class Grid:

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -38,7 +38,7 @@ def test_centered_difference_monomials():
     if default_fdtype() != np.float64 or not jax.config.x64_enabled:
         pytest.skip("float64 not available")
 
-    x = jnp.linspace(-1, 1, 9)
+    x = jnp.linspace(-1, 1, 9, dtype=float)
     dx = x[1] - x[0]
 
     for p in range(17):
@@ -64,7 +64,7 @@ def test_centered_difference_convergence():
     error_norms_1 = jnp.zeros_like(P, dtype=float)
     error_norms_2 = jnp.zeros_like(P, dtype=float)
     for i, p in enumerate(P):
-        x = jnp.linspace(0, 1, 2 ** p + 1)
+        x = jnp.linspace(0, 1, 2 ** p + 1, dtype=float)
         dx = x[1] - x[0]
         W = jnp.full_like(x, dx)
         W = W.at[0].set(0.5 * dx)

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,5 +1,5 @@
 from bt_ocean.finite_difference import (
-    difference_coefficients, diff as centered_difference_bounded)
+    difference_coefficients, diff_bounded, diff_periodic)
 from bt_ocean.precision import default_fdtype
 
 import jax
@@ -53,7 +53,7 @@ def test_centered_difference_monomials(alpha):
                 for i in range(order):
                     diff_exact *= p - i
             for N in range(max(p + 1, order + 1), x.shape[0]):
-                diff = centered_difference_bounded(u, dx, order=order, N=N)
+                diff = diff_bounded(u, dx, order=order, N=N)
                 error_norm = abs(diff - diff_exact).max()
                 diff_exact_norm = abs(diff_exact).max()
                 if diff_exact_norm > 0:
@@ -77,12 +77,12 @@ def test_centered_difference_convergence():
         W = W.at[-1].set(0.5 * dx)
         u = jnp.sin(jnp.pi * x)
 
-        D1_error = (centered_difference_bounded(u, dx, order=1, N=3)
+        D1_error = (diff_bounded(u, dx, order=1, N=3)
                     - jnp.pi * jnp.cos(jnp.pi * x))
         error_norms_1 = error_norms_1.at[i].set(jnp.sqrt((W * (D1_error ** 2)).sum()))  # noqa: E501
         print(f"{p=:d} {error_norms_1[i]=:.6g}")
 
-        D2_error = (centered_difference_bounded(u, dx, order=2, N=3)
+        D2_error = (diff_bounded(u, dx, order=2, N=3)
                     + (jnp.pi ** 2) * jnp.sin(jnp.pi * x))
         error_norms_2 = error_norms_2.at[i].set(jnp.sqrt((W * (D2_error ** 2)).sum()))  # noqa: E501
         print(f"{p=:d} {error_norms_2[i]=:.6g}")
@@ -92,3 +92,33 @@ def test_centered_difference_convergence():
     print(f"{orders_2=}")
     assert orders_1.min() > 2
     assert orders_2.min() > 2
+
+
+def test_centered_difference_convergence_periodic():
+    if default_fdtype() != np.float64 or not jax.config.x64_enabled:
+        pytest.skip("float64 not available")
+
+    P = jnp.arange(7, 12, dtype=int)
+    error_norms_1 = jnp.zeros_like(P, dtype=float)
+    error_norms_2 = jnp.zeros_like(P, dtype=float)
+    for i, p in enumerate(P):
+        x = jnp.linspace(0, 1, 2 ** p + 1, dtype=float)[:-1]
+        dx = x[1] - x[0]
+        W = jnp.full_like(x, dx)
+        u = jnp.sin(2 * jnp.pi * x)
+
+        D1_error = (diff_periodic(u, dx, order=1, N=3)
+                    - 2 * jnp.pi * jnp.cos(2 * jnp.pi * x))
+        error_norms_1 = error_norms_1.at[i].set(jnp.sqrt((W * (D1_error ** 2)).sum()))  # noqa: E501
+        print(f"{p=:d} {error_norms_1[i]=:.6g}")
+
+        D2_error = (diff_periodic(u, dx, order=2, N=3)
+                    + 4 * (jnp.pi ** 2) * jnp.sin(2 * jnp.pi * x))
+        error_norms_2 = error_norms_2.at[i].set(jnp.sqrt((W * (D2_error ** 2)).sum()))  # noqa: E501
+        print(f"{p=:d} {error_norms_2[i]=:.6g}")
+    orders_1 = jnp.log2(error_norms_1[:-1] / error_norms_1[1:])
+    orders_2 = jnp.log2(error_norms_2[:-1] / error_norms_2[1:])
+    print(f"{orders_1=}")
+    print(f"{orders_2=}")
+    assert orders_1.min() > 1.99
+    assert orders_2.min() > 1.99

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -59,7 +59,7 @@ def test_centered_difference_monomials(alpha):
                 if diff_exact_norm > 0:
                     assert error_norm < 1e-13 * diff_exact_norm
                 else:
-                    assert error_norm < 1e-10
+                    assert error_norm < 1e-9
 
 
 def test_centered_difference_convergence():

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,0 +1,88 @@
+from bt_ocean.finite_difference import (
+    difference_coefficients, diff as centered_difference_bounded)
+from bt_ocean.precision import default_fdtype
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import sympy as sp
+
+
+def test_difference_coefficients():
+    f = sp.Rational
+
+    def verify(alpha, order, beta):
+        assert difference_coefficients(alpha, order) == tuple(map(f, beta))
+
+    # First order derivatives
+    verify((0, 1), 1, (-1, 1))
+    verify((0, -1), 1, (1, -1))
+    verify((0, 2), 1, (-f(1, 2), f(1, 2)))
+    verify((-1, 1), 1, (-f(1, 2), f(1, 2)))
+    verify((0, -2), 1, (f(1, 2), -f(1, 2)))
+    verify((0, 1, 2), 1, (-f(3, 2), 2, -f(1, 2)))
+    verify((0, -1, -2), 1, (f(3, 2), -2, f(1, 2)))
+    verify((1, 2, 3), 1, (-f(5, 2), 4, -f(3, 2)))
+    verify((-1, -2, -3), 1, (f(5, 2), -4, f(3, 2)))
+
+    # Second order derivatives
+    verify((-1, 0, 1), 2, (1, -2, 1))
+    verify((0, 1, 2, 3), 2, (2, -5, 4, -1))
+    verify((0, -1, -2, -3), 2, (2, -5, 4, -1))
+    verify((1, 2, 3, 4), 2, (3, -8, 7, -2))
+    verify((-1, -2, -3, -4), 2, (3, -8, 7, -2))
+
+
+def test_centered_difference_monomials():
+    if default_fdtype() != np.float64 or not jax.config.x64_enabled:
+        pytest.skip("float64 not available")
+
+    x = jnp.linspace(-1, 1, 9)
+    dx = x[1] - x[0]
+
+    for p in range(17):
+        u = x ** p
+        for order in range(7):
+            if order > p:
+                diff_exact = jnp.zeros_like(x)
+            else:
+                diff_exact = x ** (p - order)
+                for i in range(order):
+                    diff_exact *= p - i
+            for N in range(max(p + 1, order + 1), x.shape[0]):
+                diff = centered_difference_bounded(u, dx, order=order, N=N)
+                error_norm = abs(diff - diff_exact).max()
+                assert error_norm < 1e-11
+
+
+def test_centered_difference_convergence():
+    if default_fdtype() != np.float64 or not jax.config.x64_enabled:
+        pytest.skip("float64 not available")
+
+    P = jnp.arange(7, 12, dtype=int)
+    error_norms_1 = jnp.zeros_like(P, dtype=float)
+    error_norms_2 = jnp.zeros_like(P, dtype=float)
+    for i, p in enumerate(P):
+        x = jnp.linspace(0, 1, 2 ** p + 1)
+        dx = x[1] - x[0]
+        W = jnp.full_like(x, dx)
+        W = W.at[0].set(0.5 * dx)
+        W = W.at[-1].set(0.5 * dx)
+        u = jnp.sin(jnp.pi * x)
+
+        D1_error = (centered_difference_bounded(u, dx, order=1, N=3)
+                    - jnp.pi * jnp.cos(jnp.pi * x))
+        error_norms_1 = error_norms_1.at[i].set(jnp.sqrt((W * (D1_error ** 2)).sum()))  # noqa: E501
+        print(f"{p=:d} {error_norms_1[i]=:.6g}")
+
+        D2_error = (centered_difference_bounded(u, dx, order=2, N=3)
+                    + (jnp.pi ** 2) * jnp.sin(jnp.pi * x))
+        error_norms_2 = error_norms_2.at[i].set(jnp.sqrt((W * (D2_error ** 2)).sum()))  # noqa: E501
+        print(f"{p=:d} {error_norms_2[i]=:.6g}")
+    orders_1 = jnp.log2(error_norms_1[:-1] / error_norms_1[1:])
+    orders_2 = jnp.log2(error_norms_2[:-1] / error_norms_2[1:])
+    print(f"{orders_1=}")
+    print(f"{orders_2=}")
+    assert orders_1.min() > 2
+    assert orders_2.min() > 2


### PR DESCRIPTION
Arbitrary order centered finite differencing. Currently unrolls the expression. Differencing transitions, becoming increasingly one-sided as boundaries are approached. Now used by `Grid` in `Grid.D_x`, `Grid.D_y`, `Grid.D_xx`, and `Grid.D_yy`.